### PR TITLE
Added fix for default headers not being passed through

### DIFF
--- a/lib/backbone-requester.js
+++ b/lib/backbone-requester.js
@@ -73,7 +73,9 @@ BackboneRequester.prototype = {
       }
 
       // Allow user to override our options
+      var paramsHeaders = _.extend(params.headers, options.headers);
       _.extend(params, options);
+      params.headers = paramsHeaders;
 
       // Map parameters to request parameters
       var reqParams = {

--- a/test/backbone-requester-test.js
+++ b/test/backbone-requester-test.js
@@ -176,3 +176,27 @@ describe('A Backbone model retrieving from a downed server', function () {
     expect(this.err).to.have.property('code', 'ECONNREFUSED');
   });
 });
+
+describe('A Backbone model request with custom headers', function () {
+  FakeReqres.run(['GET 200 /api/users/:id#headers']);
+  testUtils.request(function getItem (requestOptions) {
+    this.user = new UserModel({id: 2});
+    this.user.fetch(_.defaults({
+      headers: {
+        'X-Hello': 'World'
+      }
+    }, requestOptions));
+  });
+  after(function cleanup () {
+    delete this.user;
+  });
+
+  it('has custom headers at the server', function () {
+    expect(this.err).to.equal(null);
+    expect(this.user.attributes).to.have.property('x-hello', 'World');
+  });
+
+  it('has default headers at the server', function () {
+    expect(this.user.attributes).to.have.property('accept', 'application/json');
+  });
+});

--- a/test/utils/fake-reqres.js
+++ b/test/utils/fake-reqres.js
@@ -10,6 +10,15 @@ var reqresNineTrack = nineTrack({
   fixtureDir: __dirname + '/../test-files/reqres-nine-track/'
 });
 
+// Add a method to test headers
+fakeReqres.addFixture('GET 200 /api/users/:id#headers', {
+  method: 'get',
+  route: '/api/users/:id',
+  response: function (req, res) {
+    res.send(req.headers);
+  }
+});
+
 // Add a method to proxy anything
 fakeReqres.addFixture('ALL * *', {
   method: 'all',


### PR DESCRIPTION
While building out more of a system, we discovered that we were overriding headers entirely rather than extending them. To remedy that, we are moving to extension. In this PR:
- Added fix for headers
- Added tests
