### PR TITLE
Pass along options when calling request

### DIFF
--- a/lib/backbone-requester.js
+++ b/lib/backbone-requester.js
@@ -73,16 +73,15 @@ BackboneRequester.prototype = {
       }
 
       // Allow user to override our options
+      _.extend(params,
+        _.omit(options, 'headers', 'type')
+      );
+      params.method = params.type;
+
       var paramsHeaders = _.extend(params.headers, options.headers);
-      _.extend(params, options);
       params.headers = paramsHeaders;
 
-      // Map parameters to request parameters
-      var reqParams = {
-        url: params.url,
-        method: params.type,
-        headers: params.headers
-      };
+      var reqParams = _.extend(params);
 
       if (params.data !== undefined) {
         if (params.bodyType === 'form') {


### PR DESCRIPTION
Unfortunately the tests are busted because they are using nine-track, which I think is making requests to an API that no longer exists? 

#yolo